### PR TITLE
Hogan.js: Fix require path

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,11 @@ module.exports = function (engine, data, options) {
 	}
 
 	try {
-		require(engine);
+		if (engine === "hogan") {
+			require("hogan.js");
+		} else {
+			require(engine);
+		}
 	} catch (e) {
 		throw new Error("gulp-consolidate: The template engine \"" + engine + "\" was not found. " +
 			"Did you forget to install it?\n\n    npm install --save-dev " + engine);


### PR DESCRIPTION
When using hogan.js, the engine differs from the npm package name (see https://github.com/visionmedia/consolidate.js/blob/e3f2e9499e12d3ac357d58eaf25fbee6d80342ac/lib/consolidate.js#L449).
