### PR TITLE
added ability to accept its data from file.data

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,10 @@ module.exports = function (engine, data, options) {
 			fileData = fileData(file);
 		}
 
+		if (file.data) {
+			fileData = file.data;
+		}
+
 		if (file.contents instanceof Buffer) {
 			try {
 				if (options.useContents) {

--- a/test/main.js
+++ b/test/main.js
@@ -133,6 +133,43 @@ describe("gulp-consolidate", function () {
 		stream.end();
 	});
 
+	it("should use be able to render from the file.data property", function (done) {
+		var srcFile = new gutil.File({
+			path: "test/fixtures/hello.txt",
+			cwd: "test/",
+			base: "test/fixtures",
+			contents: new Buffer("Fake {{name}}")
+		});
+
+		// add data to the file object. For testing, we're just setting it here, but in real use, use gulp-data.
+		srcFile.data = {name: 'World'};
+
+		var expectedFile = new gutil.File({
+			path: "test/expected/hello.txt",
+			cwd: "test/",
+			base: "test/expected",
+			contents: new Buffer("Fake World")
+		});
+
+		var stream = consolidate("swig", null, { useContents : true });
+
+		stream.on("error", function (err) {
+			assert(err, "errors should throw");
+			done(err);
+		});
+
+		stream.on("data", function (newFile) {
+			assert(newFile, "new file should exist");
+			assert(newFile.contents, "new file contents should exist");
+
+			assert.equal(String(newFile.contents), String(expectedFile.contents), "file contents should match expected contents");
+			done();
+		});
+
+		stream.write(srcFile);
+		stream.end();
+	});
+
 	it("should error on stream", function (done) {
 		var srcFile = new gutil.File({
 			path: "test/fixtures/hello.txt",


### PR DESCRIPTION
I've created a de-coupled (generic) data source plugin that sets a data attribute to the file object. Through the new `gulp-data` plugin the data attribute can be set from a variety of sources such a JSON file, front-matter, a database, anything really. See https://www.npmjs.org/package/gulp-data for more detail and the rationale behind it. For this to be effective, I'm asking plugin devs that receive data through the options parameter to also accept this data via the file.data property. I've made the change and have added a test. Thanks!
