### PR TITLE
Options set in gulp pipe will not pass through to templating engine.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ module.exports = function (engine, data, options) {
 			fileData = fileData(file);
 		}
 
+		for (var key in options) { fileData[key] = options[key]; }
+
 		if (file.contents instanceof Buffer) {
 			try {
 				if (options.useContents) {


### PR DESCRIPTION
Registering partials and helpers for handlebars won't work without passing the options to the template engine. It just seems the options object was implemented and then forgotten.
