### PR TITLE
Update consolidate to v0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-consolidate",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Template engine consolidation for gulp",
   "keywords": [
     "gulpplugin"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "mocha -R spec"
   },
   "dependencies": {
-    "consolidate": "~0.10.0",
+    "consolidate": "~0.14.0",
     "map-stream": "0.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently unable to change `consolidate.requires.nunjucks` because that functionality isn't available until a later consolidate version not used by `gulp-consolidate`